### PR TITLE
Small style improvements to marker labels

### DIFF
--- a/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
+++ b/DynmapCore/src/main/resources/extracted/web/css/dynmap_style.css
@@ -905,15 +905,15 @@
 
     color: #fff;
     background: rgba(0,0,0,0.6);
-    padding: 2px;
+    padding: 2px 6px;
 
     -moz-border-radius: 3px;
     border-radius: 3px;
 }
 
 .dynmap .mapMarker .markerName16x16 {
-	top: -6px;
-	left: 10px;
+	top: -12px;
+	left: 12px;
 }
 
 .dynmap .mapMarker .markerName8x8 {


### PR DESCRIPTION
I noticed that marker labels in the web client were not vertically centered, as seen in the below screenshot:

![Screen Shot 2022-03-05 at 3 17 21 PM](https://user-images.githubusercontent.com/8846738/156903729-7b304395-a6ef-4ddf-a601-001b3ad1d5da.png)

I made some small style improvements so that the labels are now vertically centered with their icons. I also increased the horizontal padding for the labels from `2px` to `6px` which looks just a little nicer, as you can see in the below screenshot:

![Screen Shot 2022-03-05 at 3 35 37 PM](https://user-images.githubusercontent.com/8846738/156903759-8c448009-7929-4b94-9a1e-475f41d5b916.png)

The icons in the two screenshots are different but that is completely unrelated to this change.

Let me know if you have any questions or if there is anything else that I need to update with this change 😃 